### PR TITLE
Remove netProc from build because it does not compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ option(qmsg_INSTALL "Install the QMsg Components" ON)
 # Option to control buildomg components requiring quicr
 # (Ideally, this option should not be here, but it's needed since quicr
 # is not readily available on all platforms)
-option(qmsg_ENABLE_QUICR "Enable quicr components" ON)
+option(qmsg_ENABLE_QUICR "Enable quicr components" OFF)
 
 project(QMsg
         VERSION 1.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
 WORKDIR /src/qmsg/build
 RUN make -j 4
 
-RUN cp  src/uiProc/uiProc  /usr/local/bin/.
-RUN cp  src/netProc/netProc  /usr/local/bin/.
+RUN cp src/uiProc/uiProc  /usr/local/bin/.
+#RUN cp src/netProc/netProc  /usr/local/bin/.
 
 RUN cp  src/slowRelay/slowRelay  /usr/local/bin/.
 RUN cp  src/slowTest/slowTest  /usr/local/bin/.
@@ -54,7 +54,7 @@ RUN apk add --no-cache bash tcsh
 COPY --from=builder /usr/local/bin/uiProc /usr/local/bin/.
 #COPY --from=builder /usr/local/bin/secProc /usr/local/bin/.
 COPY --from=builder /usr/local/bin//sec-proc /usr/local/bin/.
-COPY --from=builder /usr/local/bin/netProc /usr/local/bin/.
+#COPY --from=builder /usr/local/bin/netProc /usr/local/bin/.
 
 COPY --from=builder /usr/local/bin/slowRelay /usr/local/bin/.
 COPY --from=builder /usr/local/bin/slowTest /usr/local/bin/.


### PR DESCRIPTION
@suhasHere - I'm going to just check this in because too much stuff is not working and once netProc builds, we can revert this 